### PR TITLE
Fixed two issues and add cached-path as dependencies in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 numpy==1.25
 python-crfsuite==0.9.9
 sentencepiece==0.2.0
-cached_path==1.5.0
+cached-path==1.5.0
 
 # TensorFlow + compatible addons
-tensorflow==2.13.0
+tensorflow==2.15.0
 tensorflow-estimator==2.15.0
 tensorflow-addons==0.21.0
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "python-crfsuite",
         "sentencepiece",
         "matplotlib",
+        "cached-path",
         "GitPython"
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
I have addressed the issue related to the use of the underscore in `cached_path` versus `cached-path`.

Additionally, I noticed inconsistencies between the versions specified in setup.py and requirements.py, and I have aligned them to be the same.

I also added `cached-path` as a dependency in setup.py, since `pip install .` does not automatically install it.

Please find a screenshot below as proof that the fix works:

<img width="1854" height="539" alt="Screenshot from 2026-03-19 16-42-15" src="https://github.com/user-attachments/assets/6dd1c50c-f06b-4387-b686-5ca34ee8f4a9" />
